### PR TITLE
A couple bug fixes!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nightlight"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["smudge <nathan@ngriffith.com>"]
 edition = "2018"
 categories = ["command-line-utilities", "os::macos-apis"]

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ fn main() {
 - [X] Make time display as properly-formatted 12-hour time
 - [ ] Use system config for time parse/format (12 vs 24).
 - [ ] API improvements and full documentation
+- [ ] Consider command outputs: concise, human-readable, machine-parsable.
 - [ ] Test coverage of schedule/time parsing.
 - [ ] Tests that use fake/stub ObjC library.
 - [ ] Support for "Automatically adjust brightness" feature.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ nightlight status
 In addition to a CLI, `nightlight` can be pulled-in as a dependency for other Rust crates:
 
 ```
-nightlight = "0.0.5"
+nightlight = "0.0.6"
 ```
 
 Here's an example `fn` that toggles Night Shift off,

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ fn main() {
 - [ ] API improvements and full documentation
 - [ ] Test coverage of schedule/time parsing.
 - [ ] Tests that use fake/stub ObjC library.
+- [ ] Support for "Automatically adjust brightness" feature.
 - [ ] Cross-platform support (e.g. Windows' "Night Light")
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ fn main() {
 * GitHub user `jenghis` for the (now archived) [nshift](https://github.com/jenghis/nshift) repo/CLI
 * The maintainers of the Rust [objc crate](https://github.com/SSheldon/rust-objc)
 * Carol Nichols and Steve Klabnik for the [official book](https://doc.rust-lang.org/book/) on Rust
+* ABH, CB, JP, MF, and MK for brainstorming crate names with me
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,9 @@ fn main() {
 - [X] Ability to see current status of Night Shift
 - [X] Ability to enable/disable sunrise/sundown schedule
 - [X] Ability to enable/disable custom schedules
-- [ ] Ensure that changing schedule doesn't affect on/off state.
+- [X] Ensure that changing schedule doesn't affect on/off state.
+- [X] Make time display as properly-formatted 12-hour time
+- [ ] Use system config for time parse/format (12 vs 24).
 - [ ] API improvements and full documentation
 - [ ] Test coverage of schedule/time parsing.
 - [ ] Tests that use fake/stub ObjC library.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,14 +35,17 @@ impl NightLight {
     }
 
     pub fn set_schedule(&self, schedule: Schedule) -> Result<(), String> {
+        let was_on = self.status()?.currently_active;
+
         match schedule {
-            Schedule::Off => self.client.set_mode(0),
-            Schedule::SunsetToSunrise => self.client.set_mode(1),
+            Schedule::Off => self.client.set_mode(0)?,
+            Schedule::SunsetToSunrise => self.client.set_mode(1)?,
             Schedule::Custom(from, to) => {
                 self.client.set_mode(2)?;
-                self.client.set_schedule(from.tuple(), to.tuple())
+                self.client.set_schedule(from.tuple(), to.tuple())?
             }
         }
+        self.toggle(was_on)
     }
 
     pub fn set_temp(&self, temp: i32) -> Result<(), String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,8 @@ impl NightLight {
     }
 
     fn schedule(mode: i32, from: (u8, u8), to: (u8, u8)) -> Result<Schedule, String> {
-        let from = Time::from_tuple(from);
-        let to = Time::from_tuple(to);
+        let from = Time::from_tuple(from)?;
+        let to = Time::from_tuple(to)?;
 
         match mode {
             0 => Ok(Schedule::Off),

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,11 +26,7 @@ fn print_status(status: Status) {
         Schedule::SunsetToSunrise => "Sunrise",
         Schedule::Off => "Tomorrow",
         Schedule::Custom(from_time, to_time) => {
-            println!(
-                "From:\n=> {} to {}",
-                from_time.to_string(),
-                to_time.to_string()
-            );
+            println!("From:\n=> {} to {}", from_time, to_time);
             "Tomorrow"
         }
     };

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -38,7 +38,7 @@ impl Time {
     }
 
     pub fn to_string(&self) -> String {
-        self.inner.format("%-I:%M%P")
+        self.inner.format("%-I:%M%p")
     }
 }
 

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -3,8 +3,7 @@ extern crate time;
 use std::fmt;
 
 pub struct Time {
-    hour: u8,
-    min: u8,
+    inner: time::Time,
 }
 
 impl Time {
@@ -22,27 +21,30 @@ impl Time {
         // TODO: Look at system locale and decide if am/pm can be inferred.
 
         match time {
-            Ok(time) => Ok(Time {
-                hour: time.hour(),
-                min: time.minute(),
-            }),
+            Ok(time) => Ok(Time { inner: time }),
             Err(_) => Err(format!("Invalid string value '{}'", value)),
         }
     }
 
-    pub fn from_tuple(tuple: (u8, u8)) -> Time {
-        Time {
-            hour: tuple.0,
-            min: tuple.1,
+    pub fn from_tuple(tuple: (u8, u8)) -> Result<Time, String> {
+        match time::Time::try_from_hms(tuple.0, tuple.1, 0) {
+            Ok(time) => Ok(Time { inner: time }),
+            Err(_) => Err("Unable to read time value".to_string()),
         }
     }
 
     pub fn tuple(&self) -> (u8, u8) {
-        (self.hour, self.min)
+        (self.inner.hour(), self.inner.minute())
     }
 
     pub fn to_string(&self) -> String {
-        format!("{}:{}", self.hour, self.min)
+        self.inner.format("%-I:%M%P")
+    }
+}
+
+impl fmt::Display for Time {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.to_string())
     }
 }
 


### PR DESCRIPTION
- Make `nightlight status` display time in a sane way. (e.g. instead of `6:0`, print `6pm`)
- Ensure that changing the schedule doesn't also change the on/off status.
  - This might be slightly controversial, but the annoyance of having to run a second command is greatly outweighed by the annoyance of changing the schedule in the middle of the night and having your laptop surprise you with a blue light attack.
  - This also means that if you mis-type the schedule, you won't get immediate feedback. But in an upcoming API redesign I'm aiming to give each subcommand a concise, useful output.
- Improvements to the underlying representation of "Time"